### PR TITLE
Update Discord Webhook to use embeds instead of raw text to avoid 2000 character limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+Thumbs.db

--- a/src/Encounter.js
+++ b/src/Encounter.js
@@ -26,19 +26,16 @@ class Encounter extends Component {
       totalDps: this.props.ENCDPS,
       maxhit: maxhitName
     }
-    const encounterRow = `\`${'='.repeat(
-      85
-    )}\`\n\`${encData.title} | ${encData.zone} | ${encData.duration} | ${encData.totalDps} | ${encData.maxhit}\`\n\`${'-'.repeat(
-      85
-    )}\``
 
     const data = this.props.discordData
 
     // [JOB] CHARACTER | 💪 DPS (DPS%) | 💊 HEAL (HEAL%) | 💀 DEATH | 💣 CRIT% | 🎯 DHIT% |`
     const combatantRow = data.map(combatant => {
-      return `\n**[${combatant.job}] ${combatant.characterName}** \`| DPS: ${combatant.dps} (${combatant.damage}%) | HPS: ${combatant.hps} (${combatant.healed}) | DIE: ${combatant.deaths} | CRIT: ${combatant.crit} | DHIT: ${combatant.dhit} |\`\n\`${'-'.repeat(
-        85
-      )}\``
+      return {
+        name: `[${combatant.job}] ${combatant.characterName}:`,
+        value: `**DPS:** ${combatant.dps} (${combatant.damage}%)\n**HPS:** ${combatant.hps} (${combatant.healed})\n**DIE:** ${combatant.deaths}\n**CRIT:** ${combatant.crit}\n**DHIT:** ${combatant.dhit}`,
+        inline: true
+      }
     })
 
     fetch(this.props.config.discord, {
@@ -51,7 +48,12 @@ class Encounter extends Component {
         username: 'H O R I Z O V E R L A Y',
         avatar_url:
           'https://68.media.tumblr.com/2d83ce19282a68c3e2365be87254ae6a/tumblr_oh9wzyYbdb1u9t5z9o1_500.gif',
-        content: `${encounterRow}${combatantRow.join('', ',')}`
+        embeds: [{
+          title: `__${encData.title} | ${encData.zone}__`,
+          description: `**Duration:** ${encData.duration}\n**Total DPS:** ${encData.totalDps}\n**Max Hit:** ${encData.maxhit}`,
+          color: 0x22009d,
+          fields: combatantRow
+        }]
       })
     })
   }


### PR DESCRIPTION
Update Discord Webhook to use embeds instead of raw text to avoid 2000 character limit.  This limit could be hit by alliance raids, and in extremely rare cases 8 man dungeons/raids.

Fixes issue #84

Before and After comparison:
![image](https://user-images.githubusercontent.com/4857681/210944688-6f4f172a-b496-450b-930f-19c3b767a6e1.png)

Alliance Raid example:
![image](https://user-images.githubusercontent.com/4857681/210944807-24920daf-ba63-42ab-bf86-8f2cdf194f9f.png)
